### PR TITLE
Moved commands into code blocks to fix rendering and improve readability

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,25 +40,25 @@ Build & Run
 
 1) Build this project so bundles are deployed into your local maven repo
 
-<project home> $ mvn clean install
+    <project home> $ mvn clean install
 
 2) Start JBoss Fuse
 
-<JBoss Fuse home>  $ bin/fuse
+    <JBoss Fuse home>  $ bin/fuse
 
 3) Add this projects features.xml config to Fuse from the Console
    (makes it easier to install bundles with all required dependencies)
 
-JBossFuse:karaf@root>  features:addUrl mvn:org.fusesource.examples/rider-auto-common/4.0-SNAPSHOT/xml/features
+    JBossFuse:karaf@root>  features:addUrl mvn:org.fusesource.examples/rider-auto-common/4.0-SNAPSHOT/xml/features
 
 4) Install the project.
 
-JBossFuse:karaf@root>  features:install rider-auto-osgi
+    JBossFuse:karaf@root>  features:install rider-auto-osgi
 
 5) To test the file processing, there are existing files in the
    rider-auto-common module.
 
-<project home> $ cp rider-auto-common/src/data/message1.xml <JBoss Fuse home>/target/placeorder
+    <project home> $ cp rider-auto-common/src/data/message1.xml <JBoss Fuse home>/target/placeorder
 
    To see what happened look at the log file, either from the console
 
@@ -66,7 +66,7 @@ JBossFuse:karaf@root>  log:display
 
    or from the command line
 
-<JBoss Fuse home> $ tail -f data/log/fuseesb.log
+    <JBoss Fuse home> $ tail -f data/log/fuseesb.log
 
 6) To test the WS, use your favorite WS tool (e.g. SoapUI) against the following
    WSDL hosted by the rider-auto-ws bundle.


### PR DESCRIPTION
This:

```
<project home> $ cp rider-auto-common/src/data/message1.xml <JBoss Fuse home>/target/placeorder
```

was rendering as:

<project home> $ cp rider-auto-common/src/data/message1.xml <JBoss Fuse home>/target/placeorder

Which is incorrect due to the angle bracketed text being omitted. The easy fix is to put the commands in code blocks. I think this also slightly improves readability.
